### PR TITLE
Update SORI SDK to 5.0.3 and add credential preflight

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.14.0'
     implementation 'com.google.guava:guava:33.6.0-android'
     implementation 'com.squareup.picasso:picasso:2.8'
-    implementation "com.iplateia:sorisdk:5.0.1-beta6"
+    implementation "com.iplateia:sorisdk:5.0.3"
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'androidx.navigation:navigation-ui-ktx:2.9.8'
     implementation 'androidx.navigation:navigation-fragment-ktx:2.9.8'

--- a/app/src/main/java/com/iplateia/sori/example/MainActivity.kt
+++ b/app/src/main/java/com/iplateia/sori/example/MainActivity.kt
@@ -28,7 +28,8 @@ class MainActivity : AppCompatActivity() {
     private lateinit var adapter: CampaignAdapter
     private lateinit var appBarConfiguration: AppBarConfiguration
     private lateinit var binding: ActivityMainBinding
-    private lateinit var sori: SORIAudioRecognizer
+    private var sori: SORIAudioRecognizer? = null
+    private var credentialsConfigured = false
 
     /**
      * Checks necessary permissions for the audio recognition service.
@@ -66,7 +67,7 @@ class MainActivity : AppCompatActivity() {
         super.onStart()
 
         // Check if the app has the necessary permissions and request them if not
-        if (!checkPermission()) {
+        if (credentialsConfigured && !checkPermission()) {
             try {
                 requestPermission()
             } catch (e: Exception) {
@@ -78,30 +79,33 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // Initialize the SORI SDK with the app ID and secret key
-        sori = SORIAudioRecognizer(
-            getString(R.string.SORI_APP_ID),
-            getString(R.string.SORI_SECRET_KEY),
-        )
+        val appId = getString(R.string.SORI_APP_ID)
+        val secretKey = getString(R.string.SORI_SECRET_KEY)
+        credentialsConfigured = SoriCredentialConfiguration.isLocallyConfigured(appId, secretKey)
 
-        // Prepare listener for events
-        val listener = object : SORIListener() {
-            override fun onStateChanged(state: String) {
-                println("State changed: $state")
+        if (credentialsConfigured) {
+            // Initialize the SORI SDK only after the local configuration passes the preflight check.
+            sori = SORIAudioRecognizer(appId, secretKey).also { recognizer ->
+                // Prepare listener for events
+                val listener = object : SORIListener() {
+                    override fun onStateChanged(state: String) {
+                        println("State changed: $state")
 
-                // update the FAB based on the current state
-                updateFab(state)
-            }
-            override fun onCampaignFound(campaign: SORICampaign) {
-                println("Campaign found: ${campaign.name}")
-                adapter.addItem(campaign)
+                        // update the FAB based on the current state
+                        updateFab(state)
+                    }
+                    override fun onCampaignFound(campaign: SORICampaign) {
+                        println("Campaign found: ${campaign.name}")
+                        adapter.addItem(campaign)
 
-                // hide guide text if any campaign is found
-                findViewById<TextView>(R.id.guide_text).visibility = View.GONE
+                        // hide guide text if any campaign is found
+                        findViewById<TextView>(R.id.guide_text).visibility = View.GONE
+                    }
+                }
+
+                recognizer.setListener(this, listener)
             }
         }
-
-        sori.setListener(this, listener)
 
         // Inject user's metadata if needed
         // providing a custom metadata provider is optional
@@ -138,6 +142,10 @@ class MainActivity : AppCompatActivity() {
         adapter = CampaignAdapter(mutableListOf())
         campaignTimeline.adapter = adapter
         campaignTimeline.layoutManager = LinearLayoutManager(this)
+
+        if (!credentialsConfigured) {
+            findViewById<TextView>(R.id.guide_text).setText(R.string.sori_credentials_required)
+        }
     }
 
 
@@ -151,7 +159,7 @@ class MainActivity : AppCompatActivity() {
             ServiceState.STARTED -> {
                 binding.fab.setImageResource(android.R.drawable.ic_menu_close_clear_cancel)
                 binding.fab.setOnClickListener { view ->
-                    sori.stopRecognition(this)
+                    sori?.stopRecognition(this)
                     Snackbar.make(view, "Stop recognition...", Snackbar.LENGTH_SHORT)
                         .setAnchorView(R.id.fab).show()
                 }
@@ -159,9 +167,17 @@ class MainActivity : AppCompatActivity() {
             else -> {
                 binding.fab.setImageResource(android.R.drawable.ic_btn_speak_now)
                 binding.fab.setOnClickListener { view ->
-                    sori.startRecognition(this)
-                    Snackbar.make(view, "Start recognition...", Snackbar.LENGTH_SHORT)
-                        .setAnchorView(R.id.fab).show()
+                    if (credentialsConfigured) {
+                        sori?.startRecognition(this)
+                        Snackbar.make(view, "Start recognition...", Snackbar.LENGTH_SHORT)
+                            .setAnchorView(R.id.fab).show()
+                    } else {
+                        Snackbar.make(
+                            view,
+                            R.string.sori_credentials_required,
+                            Snackbar.LENGTH_LONG,
+                        ).setAnchorView(R.id.fab).show()
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/iplateia/sori/example/SoriCredentialConfiguration.kt
+++ b/app/src/main/java/com/iplateia/sori/example/SoriCredentialConfiguration.kt
@@ -1,13 +1,18 @@
 package com.iplateia.sori.example
 
 internal object SoriCredentialConfiguration {
-    private val commonPlaceholders = setOf(
+    private val commonPlaceholderPatterns = setOf(
         "CHANGE_ME",
         "CHANGEME",
-        "EXAMPLE",
         "PLACEHOLDER",
         "REPLACE_ME",
+        "REPLACE_WITH",
+    )
+
+    private val commonPlaceholderTokens = setOf(
+        "EXAMPLE",
         "SAMPLE",
+        "TODO",
     )
 
     private val appIdPlaceholders = setOf(
@@ -19,6 +24,13 @@ internal object SoriCredentialConfiguration {
         "YOUR_APP_ID_HERE",
     )
 
+    private val appIdPlaceholderPatterns = setOf(
+        "EXAMPLE_APP_ID",
+        "SAMPLE_APP_ID",
+        "SORI_APP_ID",
+        "YOUR_APP_ID",
+    )
+
     private val secretKeyPlaceholders = setOf(
         "EXAMPLE_SECRET_KEY",
         "SAMPLE_SECRET_KEY",
@@ -28,12 +40,23 @@ internal object SoriCredentialConfiguration {
         "YOUR_SECRET_KEY_HERE",
     )
 
+    private val secretKeyPlaceholderPatterns = setOf(
+        "EXAMPLE_SECRET_KEY",
+        "SAMPLE_SECRET_KEY",
+        "SORI_SECRET_KEY",
+        "YOUR_SECRET_KEY",
+    )
+
     fun isLocallyConfigured(appId: String, secretKey: String): Boolean {
-        return isConfiguredValue(appId, appIdPlaceholders) &&
-            isConfiguredValue(secretKey, secretKeyPlaceholders)
+        return isConfiguredValue(appId, appIdPlaceholders, appIdPlaceholderPatterns) &&
+            isConfiguredValue(secretKey, secretKeyPlaceholders, secretKeyPlaceholderPatterns)
     }
 
-    private fun isConfiguredValue(value: String, fieldPlaceholders: Set<String>): Boolean {
+    private fun isConfiguredValue(
+        value: String,
+        fieldPlaceholders: Set<String>,
+        fieldPlaceholderPatterns: Set<String>,
+    ): Boolean {
         val normalized = value
             .trim()
             .removeSurrounding("\"")
@@ -42,8 +65,11 @@ internal object SoriCredentialConfiguration {
             .replace(Regex("[^A-Z0-9]+"), "_")
             .trim('_')
 
+        val tokens = normalized.split('_')
         return normalized.isNotEmpty() &&
-            normalized !in commonPlaceholders &&
-            normalized !in fieldPlaceholders
+            normalized !in fieldPlaceholders &&
+            commonPlaceholderPatterns.none(normalized::contains) &&
+            commonPlaceholderTokens.none(tokens::contains) &&
+            fieldPlaceholderPatterns.none(normalized::contains)
     }
 }

--- a/app/src/main/java/com/iplateia/sori/example/SoriCredentialConfiguration.kt
+++ b/app/src/main/java/com/iplateia/sori/example/SoriCredentialConfiguration.kt
@@ -1,0 +1,49 @@
+package com.iplateia.sori.example
+
+internal object SoriCredentialConfiguration {
+    private val commonPlaceholders = setOf(
+        "CHANGE_ME",
+        "CHANGEME",
+        "EXAMPLE",
+        "PLACEHOLDER",
+        "REPLACE_ME",
+        "SAMPLE",
+    )
+
+    private val appIdPlaceholders = setOf(
+        "APP_ID",
+        "EXAMPLE_APP_ID",
+        "SAMPLE_APP_ID",
+        "SORI_APP_ID",
+        "YOUR_APP_ID",
+        "YOUR_APP_ID_HERE",
+    )
+
+    private val secretKeyPlaceholders = setOf(
+        "EXAMPLE_SECRET_KEY",
+        "SAMPLE_SECRET_KEY",
+        "SECRET_KEY",
+        "SORI_SECRET_KEY",
+        "YOUR_SECRET_KEY",
+        "YOUR_SECRET_KEY_HERE",
+    )
+
+    fun isLocallyConfigured(appId: String, secretKey: String): Boolean {
+        return isConfiguredValue(appId, appIdPlaceholders) &&
+            isConfiguredValue(secretKey, secretKeyPlaceholders)
+    }
+
+    private fun isConfiguredValue(value: String, fieldPlaceholders: Set<String>): Boolean {
+        val normalized = value
+            .trim()
+            .removeSurrounding("\"")
+            .removeSurrounding("'")
+            .uppercase()
+            .replace(Regex("[^A-Z0-9]+"), "_")
+            .trim('_')
+
+        return normalized.isNotEmpty() &&
+            normalized !in commonPlaceholders &&
+            normalized !in fieldPlaceholders
+    }
+}

--- a/app/src/main/java/com/iplateia/sori/example/SoriCredentialConfiguration.kt
+++ b/app/src/main/java/com/iplateia/sori/example/SoriCredentialConfiguration.kt
@@ -27,7 +27,6 @@ internal object SoriCredentialConfiguration {
     private val appIdPlaceholderPatterns = setOf(
         "EXAMPLE_APP_ID",
         "SAMPLE_APP_ID",
-        "SORI_APP_ID",
         "YOUR_APP_ID",
     )
 
@@ -43,7 +42,6 @@ internal object SoriCredentialConfiguration {
     private val secretKeyPlaceholderPatterns = setOf(
         "EXAMPLE_SECRET_KEY",
         "SAMPLE_SECRET_KEY",
-        "SORI_SECRET_KEY",
         "YOUR_SECRET_KEY",
     )
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,5 +4,9 @@
     <string name="help_message">
         To start audio recognition, press the mic button below.
     </string>
+    <string name="sori_credentials_required">
+        Valid SORI credentials are required. Copy local.properties.dist to local.properties in the
+        project root, replace SORI_APP_ID and SORI_SECRET_KEY with real values, then rebuild the app.
+    </string>
     <string name="clear_state">Clear state</string>
 </resources>

--- a/app/src/test/java/com/iplateia/sori/example/SoriCredentialConfigurationTest.kt
+++ b/app/src/test/java/com/iplateia/sori/example/SoriCredentialConfigurationTest.kt
@@ -62,5 +62,11 @@ class SoriCredentialConfigurationTest {
                 "locally-configured-secret",
             ),
         )
+        assertTrue(
+            SoriCredentialConfiguration.isLocallyConfigured(
+                "production-sori-app-id-123",
+                "production-sori-secret-key-123",
+            ),
+        )
     }
 }

--- a/app/src/test/java/com/iplateia/sori/example/SoriCredentialConfigurationTest.kt
+++ b/app/src/test/java/com/iplateia/sori/example/SoriCredentialConfigurationTest.kt
@@ -1,0 +1,43 @@
+package com.iplateia.sori.example
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SoriCredentialConfigurationTest {
+    @Test
+    fun rejectsBlankValues() {
+        assertFalse(SoriCredentialConfiguration.isLocallyConfigured("", "secret-value"))
+        assertFalse(SoriCredentialConfiguration.isLocallyConfigured("app-id", "   "))
+    }
+
+    @Test
+    fun rejectsDocumentedPlaceholderValues() {
+        assertFalse(
+            SoriCredentialConfiguration.isLocallyConfigured(
+                "\"YOUR_APP_ID_HERE\"",
+                "\"YOUR_SECRET_KEY_HERE\"",
+            ),
+        )
+    }
+
+    @Test
+    fun rejectsOtherObviousTemplateValues() {
+        assertFalse(
+            SoriCredentialConfiguration.isLocallyConfigured(
+                "<sori-app-id>",
+                "replace me",
+            ),
+        )
+    }
+
+    @Test
+    fun acceptsNonPlaceholderValuesWithoutClaimingServerValidity() {
+        assertTrue(
+            SoriCredentialConfiguration.isLocallyConfigured(
+                "locally-configured-app-id",
+                "locally-configured-secret",
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/iplateia/sori/example/SoriCredentialConfigurationTest.kt
+++ b/app/src/test/java/com/iplateia/sori/example/SoriCredentialConfigurationTest.kt
@@ -32,6 +32,29 @@ class SoriCredentialConfigurationTest {
     }
 
     @Test
+    fun rejectsPatternedPlaceholderValues() {
+        assertFalse(SoriCredentialConfiguration.isLocallyConfigured("TODO", "secret-value"))
+        assertFalse(
+            SoriCredentialConfiguration.isLocallyConfigured(
+                "replace-with-your-app-id",
+                "secret-value",
+            ),
+        )
+        assertFalse(
+            SoriCredentialConfiguration.isLocallyConfigured(
+                "YOUR_APP_ID_HERE_123",
+                "secret-value",
+            ),
+        )
+        assertFalse(
+            SoriCredentialConfiguration.isLocallyConfigured(
+                "app-id",
+                "replace-with-your-secret-key",
+            ),
+        )
+    }
+
+    @Test
     fun acceptsNonPlaceholderValuesWithoutClaimingServerValidity() {
         assertTrue(
             SoriCredentialConfiguration.isLocallyConfigured(

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '9.2.1' apply false
-    id 'com.android.library' version '9.2.1' apply false
+    id 'com.android.application' version '9.3.1' apply false
+    id 'com.android.library' version '9.3.1' apply false
 }


### PR DESCRIPTION
## Summary
- update `com.iplateia:sorisdk` from `5.0.1-beta6` to the stable `5.0.3` release
- update the Android Gradle Plugin from `9.2.1` to stable `9.3.1` while retaining compatible Gradle `9.6.1`
- add a local credential preflight that blocks SDK initialization, permission prompts, and recognition startup for blank or obvious placeholder values
- reject exact and patterned placeholders, including `TODO`, `replace-with-your-app-id`, and suffixed documented templates
- keep neutral labels such as `SORI_APP_ID` exact-only so ordinary values like `production-sori-app-id-123` are not falsely rejected
- show persistent, actionable setup guidance in the sample UI and repeat it when the mic button is tapped
- add focused unit coverage for missing, exact placeholder, patterned template, and ordinary non-placeholder configurations

## Rationale
The sample should consume the released SORI SDK and current stable compatible build tooling. It should also guide developers immediately when sample credentials have not been replaced instead of attempting authentication and eventually reporting `authentication_failed`.

The preflight is intentionally local-only. It recognizes missing and obvious placeholder configuration; it does not claim to validate whether non-placeholder credentials are accepted by the SORI service.

## Dependency audit
- confirmed `5.0.3` is the `latest` and `release` version in the sample's configured SORI Maven repository, with both POM and AAR returning HTTP 200
- confirmed AGP `9.3.1` is the current stable release and Gradle `9.6.1` satisfies its compatibility requirement
- audited every other direct app dependency and test dependency against its configured repository; they are already on their current stable compatible versions
- excluded alpha, beta, and RC releases; this project has no dependency lockfile to update

## Validation
- `./gradlew :app:dependencyInsight --configuration debugRuntimeClasspath --dependency com.iplateia:sorisdk`
  - resolved `com.iplateia:sorisdk:5.0.3` as a release variant with AGP `9.3.1`
- `./gradlew :app:dependencies --configuration debugRuntimeClasspath`
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:lintDebug`
- `./gradlew :app:assembleDebug`
- focused regression: `./gradlew :app:testDebugUnitTest --tests com.iplateia.sori.example.SoriCredentialConfigurationTest`
  - covers exact and patterned placeholder rejection plus acceptance of ordinary values containing neutral SORI field labels
- emulator smoke test on `Medium_Phone_API_36.1`
  - installed the debug APK from a clean app state with no local credentials
  - launched and kept `MainActivity` resumed with the actionable credential message visible
  - verified microphone and notification permissions remained unrequested
  - tapped the mic button and verified no SORI service start, `libafp.so` load, or authentication attempt occurred
  - repeated with `SORI_APP_ID=replace-with-your-app-id`; the patterned placeholder was blocked with the same guidance and zero SDK/auth attempts

## Risks and known gaps
- authenticated recognition was not exercised because production SORI credentials are not available locally
- `connectedDebugAndroidTest` was attempted, but the existing test expects stale package name `com.iplateia.sori.ExampleApp` instead of `com.iplateia.sori.example`; the same failure reproduces unchanged on `origin/main`, so it is intentionally left out of this dependency and credential-preflight scope
- Gradle reports existing Groovy space-assignment deprecation warnings scheduled for Gradle 10; this PR does not expand into unrelated DSL cleanup
